### PR TITLE
De-duplicate day of week and month of year parsing

### DIFF
--- a/Lurgle.Dates.Tests/DateTests.cs
+++ b/Lurgle.Dates.Tests/DateTests.cs
@@ -796,15 +796,15 @@ namespace Lurgle.Dates.Tests
             var timeNow = DateTime.ParseExact($"{DateTime.Today.Year}-{DateTime.Today.Month}-{DateTime.Today.Day} 9:00",
                 "yyyy-M-d H:mm", CultureInfo.InvariantCulture,
                 DateTimeStyles.None);
-            _testOutputHelper.WriteLine(string.Join(",", Dates.GetUtcDaysOfWeek("Monday,Tuesday,Wednesday,Thursday,Friday", "9:00", "H:mm").Select(d => d.ToString()).ToList()));
+            _testOutputHelper.WriteLine(string.Join(",", Dates.GetUtcDaysOfWeek("Monday,Tuesday,Wed,Wednesday,Thursday,Friday", "9:00", "H:mm").Select(d => d.ToString()).ToList()));
             if (timeNow.ToUniversalTime() == timeNow)
-                Assert.Equal(Dates.GetUtcDaysOfWeek("Monday,Tuesday,Wednesday,Thursday,Friday", "9:00", "H:mm"),
+                Assert.Equal(Dates.GetUtcDaysOfWeek("Monday,Tuesday,Wed,Wednesday,Thursday,Friday", "9:00", "H:mm"),
                     new List<DayOfWeek>()
                     {
                         DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday
                     });
             else
-                Assert.Equal(Dates.GetUtcDaysOfWeek("Monday,Tuesday,Wednesday,Thursday,Friday", "9:00", "H:mm"),
+                Assert.Equal(Dates.GetUtcDaysOfWeek("Monday,Tuesday,Wed,Wednesday,Thursday,Friday", "9:00", "H:mm"),
                     new List<DayOfWeek>()
                     {
                         DayOfWeek.Sunday, DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday
@@ -814,8 +814,8 @@ namespace Lurgle.Dates.Tests
         [Fact]
         public void ParseDaysOfWeek()
         {
-            _testOutputHelper.WriteLine(string.Join(",", Dates.GetDaysOfWeek("Monday,Tuesday,Wednesday,Thursday,Friday").Select(d => d.ToString()).ToList()));
-            Assert.Equal(Dates.GetDaysOfWeek("Monday,Tuesday,Wednesday,Thursday,Friday"),
+            _testOutputHelper.WriteLine(string.Join(",", Dates.GetDaysOfWeek("Monday,Tuesday,Wed,Wednesday,Thursday,Friday").Select(d => d.ToString()).ToList()));
+            Assert.Equal(Dates.GetDaysOfWeek("Monday,Tuesday,Wed,Wednesday,Thursday,Friday"),
                 new List<DayOfWeek>()
                 {
                     DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday

--- a/Lurgle.Dates/Dates.cs
+++ b/Lurgle.Dates/Dates.cs
@@ -270,18 +270,16 @@ namespace Lurgle.Dates
                     foreach (var day in dayArray)
                         if (Enum.TryParse(day, true, out DayOfWeek dayOfWeek))
                         {
-                            if (localStart.ToUniversalTime().DayOfWeek < localStart.DayOfWeek ||
-                                localStart.DayOfWeek == 0 && (int) utcStart.DayOfWeek == 6)
-                            {
-                                if (dayOfWeek - 1 >= 0)
-                                    dayResult.Add(dayOfWeek - 1);
-                                else
-                                    dayResult.Add(DayOfWeek.Saturday);
-                            }
-                            else
-                            {
-                                dayResult.Add(dayOfWeek);
-                            }
+                            var dow = GetUtcDayOfWeek(localStart, utcStart, dayOfWeek);
+                            if (!dayResult.Contains(dow))
+                                dayResult.Add(dow);
+                        }
+                        else if  (Enum.TryParse(day, true, out ShortDayOfWeek shortDayOfWeek))
+                        {
+                            var dow = GetUtcDayOfWeek(localStart, utcStart, (DayOfWeek)shortDayOfWeek);
+                            if (!dayResult.Contains(dow))
+                                dayResult.Add(dow);
+                            
                         }
             }
 
@@ -293,6 +291,17 @@ namespace Lurgle.Dates
                 };
 
             return dayResult;
+        }
+
+        private static DayOfWeek GetUtcDayOfWeek(DateTime localStart, DateTime utcStart, DayOfWeek dayOfWeek)
+        {
+            if (localStart.ToUniversalTime().DayOfWeek >= localStart.DayOfWeek &&
+                (localStart.DayOfWeek != 0 || (int)utcStart.DayOfWeek != 6)) return dayOfWeek;
+            if (dayOfWeek - 1 >= 0)
+                return dayOfWeek - 1;
+
+            return DayOfWeek.Saturday;
+
         }
 
         /// <summary>
@@ -313,9 +322,12 @@ namespace Lurgle.Dates
                 if (dayArray.Length > 0)
                     //Calculate days of week based on UTC start times
                     foreach (var day in dayArray)
-                        if (Enum.TryParse(day, true, out DayOfWeek dayOfWeek))
+                        if (Enum.TryParse(day, true, out DayOfWeek dayOfWeek) && !dayResult.Contains(dayOfWeek))
                         {
                             dayResult.Add(dayOfWeek);
+                        } else if (Enum.TryParse(day, true, out ShortDayOfWeek shortDayOfWeek) && !dayResult.Contains((DayOfWeek)shortDayOfWeek))
+                        {
+                            dayResult.Add((DayOfWeek)shortDayOfWeek);
                         }
             }
 
@@ -343,11 +355,11 @@ namespace Lurgle.Dates
                     .Select(t => t.Trim()).ToArray();
                 if (monthArray.Length > 0)
                     foreach (var month in monthArray)
-                        if (Enum.TryParse(month, true, out MonthOfYear monthOfYear))
+                        if (Enum.TryParse(month, true, out MonthOfYear monthOfYear) && !monthResult.Contains(monthOfYear))
                         {
                                 monthResult.Add(monthOfYear);
                         }
-                        else if (Enum.TryParse(month, true, out ShortMonthOfYear shortMonthOfYear))
+                        else if (Enum.TryParse(month, true, out ShortMonthOfYear shortMonthOfYear) && !monthResult.Contains((MonthOfYear)shortMonthOfYear))
                         {
                             monthResult.Add((MonthOfYear)shortMonthOfYear);
                         }

--- a/Lurgle.Dates/Enums/ShortDayOfWeek.cs
+++ b/Lurgle.Dates/Enums/ShortDayOfWeek.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Lurgle.Dates
+{
+    /// <summary>
+    /// Alternative DayOfWeek enum for short day names
+    /// </summary>
+    public enum ShortDayOfWeek
+    {
+        /// <summary>
+        /// Sunday
+        /// </summary>
+        Sun = 0,
+        /// <summary>
+        /// Monday
+        /// </summary>
+        Mon = 1,
+        /// <summary>
+        /// Tuesday
+        /// </summary>
+        Tue = 2,
+        /// <summary>
+        /// Wednesday
+        /// </summary>
+        Wed = 3,
+        /// <summary>
+        /// Thursday
+        /// </summary>
+        Thu = 4,
+        /// <summary>
+        /// Friday
+        /// </summary>
+        Fri = 5,
+        /// <summary>
+        /// Saturday
+        /// </summary>
+        Sat = 6
+    }
+}

--- a/Lurgle.Dates/Lurgle.Dates.csproj
+++ b/Lurgle.Dates/Lurgle.Dates.csproj
@@ -12,11 +12,13 @@
     <RepositoryType>Github</RepositoryType>
     <PackageTags>Lurgle date expression token calculation</PackageTags>
     <Description>A common library for calculating date expressions and formatting date tokens</Description>
-    <Version>1.0.9</Version>
+    <Version>1.0.10</Version>
     <PackageReleaseNotes>Add DateTokens.CalculateDateExpression to allow parsing a d h m token to a DateTime
 Add w to Jira-type date expressions
 Correct the Dates.ParseDaysOfWeek logic to return local days of week
-Add Dates.ParseMonthsOfYear to return local months</PackageReleaseNotes>
+Add Dates.ParseMonthsOfYear to return local months
+De-duplicate day of week and month of year parsing
+Allow for short day names to be passed to day of week parsing</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Lurgle.Dates/Lurgle.Dates.xml
+++ b/Lurgle.Dates/Lurgle.Dates.xml
@@ -555,6 +555,46 @@
             December
             </summary>
         </member>
+        <member name="T:Lurgle.Dates.ShortDayOfWeek">
+            <summary>
+            Alternative DayOfWeek enum for short day names
+            </summary>
+        </member>
+        <member name="F:Lurgle.Dates.ShortDayOfWeek.Sun">
+            <summary>
+            Sunday
+            </summary>
+        </member>
+        <member name="F:Lurgle.Dates.ShortDayOfWeek.Mon">
+            <summary>
+            Monday
+            </summary>
+        </member>
+        <member name="F:Lurgle.Dates.ShortDayOfWeek.Tue">
+            <summary>
+            Tuesday
+            </summary>
+        </member>
+        <member name="F:Lurgle.Dates.ShortDayOfWeek.Wed">
+            <summary>
+            Wednesday
+            </summary>
+        </member>
+        <member name="F:Lurgle.Dates.ShortDayOfWeek.Thu">
+            <summary>
+            Thursday
+            </summary>
+        </member>
+        <member name="F:Lurgle.Dates.ShortDayOfWeek.Fri">
+            <summary>
+            Friday
+            </summary>
+        </member>
+        <member name="F:Lurgle.Dates.ShortDayOfWeek.Sat">
+            <summary>
+            Saturday
+            </summary>
+        </member>
         <member name="T:Lurgle.Dates.Holidays">
             <summary>
                 Holidays methods


### PR DESCRIPTION
Allow for short day names to be passed to day of week parsing